### PR TITLE
Feature/modify jvm memory

### DIFF
--- a/installer/Linux/conf.ini
+++ b/installer/Linux/conf.ini
@@ -34,3 +34,9 @@ LOGGING=true
 # ---------------------------------------
 RED5PRO_DOWNLOAD_URL=
 
+# MINIMUM PERCENTAGE OF SYSTEM MEMORY TO ALLOCATE
+# ---------------------------------------
+RED5PRO_MEMORY_PCT=80
+
+
+

--- a/installer/Linux/rpro-utils.sh
+++ b/installer/Linux/rpro-utils.sh
@@ -475,14 +475,21 @@ modify_jvm_memory()
 			alloc_phymem=$(bc <<< "scale=1;$alloc_phymem/1024") # Mb to Gb
 			alloc_phymem=$(printf "%.0f" $alloc_phymem) # Round off
 
+			if [[ "$alloc_phymem" -lt 2 ]]; then
+				alloc_phymem = 2
+			fi
+
 			alloc_phymem_string="-Xmx"$alloc_phymem"g"
 
 			sed -i -e "s/-Xmx2g/$alloc_phymem_string/g" $red5_sh_file # improve this
-			
+			lecho "Memory size updated!"
+			sleep 1
+
+			if [ ! $# -eq 0 ];  then
+				pause
+			fi
 		fi
 	fi
-	
-	pause;
 }
 
 
@@ -983,6 +990,9 @@ install_rpro_zip()
 
 	# Install additional libraries
 	postrequisites
+
+	# JVM meory update
+	modify_jvm_memory
 
 
 	# Installing red5 service

--- a/installer/Linux/rpro-utils.sh
+++ b/installer/Linux/rpro-utils.sh
@@ -741,18 +741,7 @@ auto_install_rpro()
 	# Install prerequisites
 	prerequisites
 
-	# Checking java
-	lecho "Checking java requirements"
-	sleep 2
-	check_java
-
 	
-	if [ "$has_min_java_version" -eq 0 ]; then
-		echo "Installing latest java runtime environment..."
-		sleep 2
-
-		install_java
-	fi 
 
 
 	# Download red5 zip from red5pro.com
@@ -801,19 +790,6 @@ auto_install_rpro_url()
 
 	# Install prerequisites
 	prerequisites	
-
-	# Checking java
-	lecho "Checking java requirements"
-	sleep 2
-	check_java
-
-	
-	if [ "$has_min_java_version" -eq 0 ]; then
-		echo "Installing latest java runtime environment..."
-		sleep 2
-
-		install_java
-	fi 
 
 
 	# Download red5 zip from url
@@ -921,7 +897,7 @@ install_rpro_zip()
 	red5_zip_install_success=0
 
 	# Install prerequisites
-	prerequisites
+	# prerequisites [ extra not needed ]
 			
 	clear
 	lecho "Installing red5pro from zip"
@@ -2375,10 +2351,31 @@ prerequisites()
 
 	prerequisites_update
 
+	prerequisites_java
 	prerequisites_unzip
 	prerequisites_wget
 	prerequisites_bc
 }
+
+
+
+prerequisites_java()
+{
+
+	# Checking java
+	lecho "Checking java requirements"
+	sleep 2
+	check_java
+
+	
+	if [ "$has_min_java_version" -eq 0 ]; then
+		echo "Installing latest java runtime environment..."
+		sleep 2
+
+		install_java
+	fi 
+}
+
 
 
 prerequisites_update()


### PR DESCRIPTION
+ CentOs 7 support fix
+ bc utility check and install
+ Better prerequisites installation
+ Auto detect system memory and set JVM memory
+ Set how much percentage of system memory to allocate for Red5 Pro JVM process in conf.ini
+ Removed unnecessary check delays
+ Faster java install without prompt
+ Force shutdown option for Red5 Pro